### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/AEduardo-dev/flk/compare/v0.1.0...v0.1.1) - 2025-10-28
+
+### Fixed
+
+- apply clippy suggestions for struct initialization
+- add clippy suggestions
+- correct typo for actions input
+
+### Other
+
+- fix token permissions for release management
+- insert escape chars to make command name be parsed
+- update version of nix installer
+
 ### Planned
 
 - Version pinning support for packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["AEduardo-dev"]
 description = "A CLI tool for managing flake.nix files like Jetify Devbox"


### PR DESCRIPTION



## 🤖 New release

* `flk`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/AEduardo-dev/flk/compare/v0.1.0...v0.1.1) - 2025-10-28

### Fixed

- apply clippy suggestions for struct initialization
- add clippy suggestions
- correct typo for actions input

### Other

- fix token permissions for release management
- insert escape chars to make command name be parsed
- update version of nix installer

### Planned

- Version pinning support for packages
- Interactive TUI mode
- Plugin system
- Flake templates marketplace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).