### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.1.3] - 2025-10-29
+
+### 🚀 Features
+
+- Add visual spinner for command or method wrapping
+- Wrap long running nix commands with spinner output
+
+### 🐛 Bug Fixes
+
+- Make release-plz create only tags
+
+### 💼 Other
+
+- Remove release override in workspace config
+
+### ⚙️ Miscellaneous Tasks
+
+- Update issue templates
+- Remove previous templates
+- Add git cliff tool for changelog management
+- Update release-plz configuration to use git-cliff
+- Point roadmap to roadmap issue
+- Make changelog follow git-cliff format
+- Update lockfile
 ## [unreleased]
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flk"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["AEduardo-dev"]
 description = "A CLI tool for managing flake.nix files like Jetify Devbox"


### PR DESCRIPTION



## 🤖 New release

* `flk`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2025-10-29

### 🚀 Features

- Add visual spinner for command or method wrapping
- Wrap long running nix commands with spinner output

### 🐛 Bug Fixes

- Make release-plz create only tags

### 💼 Other

- Remove release override in workspace config

### ⚙️ Miscellaneous Tasks

- Update issue templates
- Remove previous templates
- Add git cliff tool for changelog management
- Update release-plz configuration to use git-cliff
- Point roadmap to roadmap issue
- Make changelog follow git-cliff format
- Update lockfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).