### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make changelog follow git-cliff format
 - Update lockfile
 ## [unreleased]
+## [0.3.0] - 2025-11-27
+
+### 🚀 Features
+
+- [**breaking**] #17 multi profile support ([#51](https://github.com/AEduardo-dev/flk/pull/51))
+- [**breaking**] Add split of commands ([#53](https://github.com/AEduardo-dev/flk/pull/53))
+- Move and adapt flake template implementations
+- Simplify base flake to follow import early approach
+- Generate profile names and permutations
+- Add auto import all files in the directory non-recursively
+- Update init command to new dendritic approach
+- Update parsers implementation (work in progress)
+- Use signal instead of exit code for refresh and switch
+- Use string literal for indent constants
+- Implement consistent brace find approach for parsing
+- Update implementation for command addition
+- Adjust base commands to manage default env
+- Fix package insertion to provide consistent indentation
+- Add profile name support for all base commands
+- Improve parsing for flake operations
+- Add profile support and improve export logic
+- Import and apply overlay files
+- Add overlay and pins for version pinning
+- Update tests
+- Allow usage of utils in tests
+- Make activation command unix and windows compatible
+
+### 🐛 Bug Fixes
+
+- Pass system input for rust overlay
+- Clippy suggestions
+- Parsing of packages with prefix
+
+### ⚙️ Miscellaneous Tasks
+
+- Remove gitignore of flk dir
+- Remove description field from flake config
+- Correct integration tests to follow new paths
+- Update unit tests for new struct
+- Add missing cargo packages
+- Make default shell extract public and independent
+- Add visual feedback during package validation
+- Remove helper hooks from flk
+- Update dev environment to new structure
+- Add impure flag to activation commands
+- Update lockfile ref
+- Adjust test to new profile outputs
+- Update documentation
+- Update tool descriptor
+- Update dist
 ## [0.2.0] - 2025-11-12
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flk"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["AEduardo-dev"]
 description = "A CLI tool for managing flake.nix devShell environments"


### PR DESCRIPTION



## 🤖 New release

* `flk`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `flk` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field FlakeConfig.profiles in /tmp/.tmp80KHsS/flk/src/flake/interface.rs:8

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function flk::flake::parser::find_env_vars, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:144
  function flk::flake::parser::add_env_var, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:431
  function flk::flake::parser::find_shell_hook, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:126
  function flk::flake::parser::parse_env_vars, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:401
  function flk::flake::generator::generate_hooks, previously in file /tmp/.tmpPTv1Az/flk/src/flake/generator.rs:21
  function flk::flake::parser::parse_description, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:31
  function flk::flake::parser::remove_package_inputs, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:258
  function flk::flake::parser::add_package_inputs, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:217
  function flk::flake::parser::find_packages_inputs, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:157
  function flk::flake::parser::remove_env_var, previously in file /tmp/.tmpPTv1Az/flk/src/flake/parser.rs:455

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  flk::flake::parser::env_var_exists now takes 3 parameters instead of 2, in /tmp/.tmp80KHsS/flk/src/flake/parser.rs:393
  flk::flake::parser::remove_command_from_shell_hook now takes 3 parameters instead of 2, in /tmp/.tmp80KHsS/flk/src/flake/parser.rs:567
  flk::flake::parser::add_command_to_shell_hook now takes 4 parameters instead of 3, in /tmp/.tmp80KHsS/flk/src/flake/parser.rs:536
  flk::flake::parser::find_command now takes 3 parameters instead of 2, in /tmp/.tmp80KHsS/flk/src/flake/parser.rs:515
  flk::flake::parser::package_exists now takes 3 parameters instead of 2, in /tmp/.tmp80KHsS/flk/src/flake/parser.rs:309

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field description of struct FlakeConfig, previously in file /tmp/.tmpPTv1Az/flk/src/flake/interface.rs:7
  field packages of struct FlakeConfig, previously in file /tmp/.tmpPTv1Az/flk/src/flake/interface.rs:9
  field env_vars of struct FlakeConfig, previously in file /tmp/.tmpPTv1Az/flk/src/flake/interface.rs:10
  field shell_hook of struct FlakeConfig, previously in file /tmp/.tmpPTv1Az/flk/src/flake/interface.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2025-10-29

### 🚀 Features

- Add visual spinner for command or method wrapping
- Wrap long running nix commands with spinner output

### 🐛 Bug Fixes

- Make release-plz create only tags

### 💼 Other

- Remove release override in workspace config

### ⚙️ Miscellaneous Tasks

- Update issue templates
- Remove previous templates
- Add git cliff tool for changelog management
- Update release-plz configuration to use git-cliff
- Point roadmap to roadmap issue
- Make changelog follow git-cliff format
- Update lockfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).