### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make changelog follow git-cliff format
 - Update lockfile
 ## [unreleased]
+## [0.5.0] - 2026-01-18
+
+### 🚀 Features
+
+- Update parsers implementation to use nom
+- Add utils for nom parsing
+- Update parsers for nom usage
+- Update packages listing method with new parsing
+- Update search operations with new parsing
+- Calculate insertion point for indentation consistency
+- Add skeleton for overlays parser and structure of future flow
+- Introduce overlays and pins parsers
+- Remove 'with pkgs' to support pin syntax
+- Pin packages in pins file
+- Update parsers and tests for overlays
+- Use new parsers for versioned packages input
+- Subdivide interfaces for easier usage
+- Expand parsing utilities
+- Use new parsing utilities for packages parsing
+- Adjust overlays file parsing for all sections
+- Add rendering utilities for nix file dumping
+- Update add and remove package commands to support pins interaction
+- Remove shell wrapper implementation
+- Remove gitignore for backup of flake lock
+- Add shellhook interfaces and update imports and mods
+- Add commands section to profiles
+- Parse commands section and render back full section
+- Use new methods in cli command implementation
+- Move mutation helpers to interfaces module
+- Refactor shell_hook to use ShellHookSection struct
+- Remove redundant comments from nix_render and overlays modules
+- Add direnv specific commands
+- Update readme with project struct and commands
+
+### 🐛 Bug Fixes
+
+- Dead code warnings
+- Remove curl from packages list for nix darwin compat
+- Use proper format for system args
+- Dead code warnings
+- Python and node template dependencies mismatches
+
+### 🚜 Refactor
+
+- Remove input loop and simplify activation flow
+
+### 📚 Documentation
+
+- Update README to include upgrade notes for v0.5.0
+- *(readme)* Add direnv commands docs and remove deprecated install
+
+### 🧪 Testing
+
+- Improve error handling in add_command tests
+
+### ⚙️ Miscellaneous Tasks
+
+- Adjust packages tests to use new parsing struct
+- Add nom dependency
+- Update tests for new parsers
+- Remove tokio dep
+- Introduce overlays and pins tests
+- Update env
+- Update structure of control files for testing
+- Update unit tests
+- Update profile test data with commands section
+- Update tests for new commands section parsing checks
+- Update python template tests
 ## [0.4.0] - 2025-12-04
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flk"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["AEduardo-dev"]
 description = "A CLI tool for managing flake.nix devShell environments"


### PR DESCRIPTION



## 🤖 New release

* `flk`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `flk` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function flk::flake::parsers::utils::find_matching_brace, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/utils.rs:6
  function flk::flake::parsers::env::remove_env_var_from_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/env.rs:123
  function flk::flake::parsers::env::add_env_var_to_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/env.rs:82
  function flk::flake::parsers::env::env_var_exists, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/env.rs:67
  function flk::flake::parsers::packages::remove_package_from_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/packages.rs:121
  function flk::flake::parsers::env::parse_env_vars_from_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/env.rs:27
  function flk::flake::parsers::packages::add_package_to_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/packages.rs:95
  function flk::flake::parsers::env::find_env_vars_in_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/env.rs:8
  function flk::flake::parsers::packages::package_exists, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/packages.rs:76
  function flk::flake::parsers::packages::parse_packages_from_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/packages.rs:36
  function flk::flake::parsers::commands::remove_command_from_shell_hook, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/commands.rs:95
  function flk::flake::parsers::utils::indent_lines, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/utils.rs:67
  function flk::flake::parsers::packages::find_packages_in_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/packages.rs:7
  function flk::flake::parsers::commands::add_command_to_shell_hook, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/commands.rs:64
  function flk::flake::parsers::commands::command_exists, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/commands.rs:60
  function flk::flake::parsers::commands::find_command, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/commands.rs:43
  function flk::flake::parsers::commands::parse_shell_hook_from_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/commands.rs:28
  function flk::flake::parsers::commands::find_shell_hook_in_profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/parsers/commands.rs:7

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod flk::flake::interface, previously in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  INDENT_OUT in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:6
  INDENT_IN in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:5

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct flk::flake::interface::FlakeConfig, previously in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:9
  struct flk::flake::interface::Profile, previously in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:16
  struct flk::flake::interface::EnvVar, previously in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:43
  struct flk::flake::interface::Package, previously in file /tmp/.tmpjCENwL/flk/src/flake/interface.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2025-10-29

### 🚀 Features

- Add visual spinner for command or method wrapping
- Wrap long running nix commands with spinner output

### 🐛 Bug Fixes

- Make release-plz create only tags

### 💼 Other

- Remove release override in workspace config

### ⚙️ Miscellaneous Tasks

- Update issue templates
- Remove previous templates
- Add git cliff tool for changelog management
- Update release-plz configuration to use git-cliff
- Point roadmap to roadmap issue
- Make changelog follow git-cliff format
- Update lockfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).