### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make changelog follow git-cliff format
 - Update lockfile
 ## [unreleased]
+## [0.5.3] - 2026-03-01
+
+### 🚀 Features
+
+- Add defaultShell attribute and conditional export to flake outputs
+- Allow specifying shell profile and improve profile selection
+- Add profile management commands
+- Support specifying target profile for add/remove commands
+- Add resolve_profile with path traversal validation
+- Add --profile flag to commands
+- Improve dev shell activation speed with GC root pinning and nix-direnv support
+
+### 🐛 Bug Fixes
+
+- Add path traversal validation to profile commands
+- Set least-privilege permissions in workflow files
+- Add profile name validation in shell hook functions
+- Add guard for empty profiles list
+- Remove Option from boolean flag
+
+### 🚜 Refactor
+
+- Simplify `run_add` signature by removing Option from force param
+
+### 📚 Documentation
+
+- Add profile management and --profile flag documentation
+
+### 🧪 Testing
+
+- Add path traversal prevention tests for profile commands
+
+### ⚙️ Miscellaneous Tasks
+
+- Add dependabot for weekly dep checks
+- Update dependencies and add regex crate
+- Add code coverage with Codecov
+- Add llvm-tools-preview for local coverage
+- Run cargo fmt
 ## [0.5.2] - 2026-01-22
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "flk"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flk"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["AEduardo-dev"]
 description = "A CLI tool for managing flake.nix devShell environments"


### PR DESCRIPTION



## 🤖 New release

* `flk`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2025-10-29

### 🚀 Features

- Add visual spinner for command or method wrapping
- Wrap long running nix commands with spinner output

### 🐛 Bug Fixes

- Make release-plz create only tags

### 💼 Other

- Remove release override in workspace config

### ⚙️ Miscellaneous Tasks

- Update issue templates
- Remove previous templates
- Add git cliff tool for changelog management
- Update release-plz configuration to use git-cliff
- Point roadmap to roadmap issue
- Make changelog follow git-cliff format
- Update lockfile
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).