### PR TITLE
Hotfix/remove root pins incremental generations

### DIFF
--- a/flk-book/src/commands/activate.md
+++ b/flk-book/src/commands/activate.md
@@ -12,7 +12,8 @@ flk activate --profile backend
 
 **Behavior**
 - Runs `nix develop .#<profile> --impure` to enter the dev shell
-- Uses GC root pinning (`.flk/.nix-profile-<profile>`) for faster re-activation on subsequent runs
+- Reuses a cached develop profile from `.flk/.nix-profile-<profile>` when your flake config is unchanged
+- Refreshes that cached profile when `flake.nix`, `flake.lock`, or the relevant `.flk` profile files change
 - Uses standard [profile resolution](../concepts.md#profiles) when `--profile` is not specified
 - Custom commands and environment variables from the profile are available inside the shell
 

--- a/flk-book/src/commands/hook.md
+++ b/flk-book/src/commands/hook.md
@@ -45,7 +45,7 @@ refresh
 - If direnv is present and `.envrc` exists, runs `direnv reload`
 - Otherwise, reuses a cached `nix develop` profile when it is still fresh
 - Rebuilds that cached profile when the flake inputs or relevant `.flk` files change
-- Uses the `FLK_FLAKE_REF` environment variable to determine the active profile
+- Uses `FLK_FLAKE_REF` (fallback: `FLK_PROFILE`) to determine the active profile
 
 ### `switch <profile>`
 
@@ -57,7 +57,7 @@ switch frontend
 ```
 
 - Validates the profile name before switching
-- Updates `FLK_FLAKE_REF` and reloads via direnv or `nix develop`
+- Updates `FLK_FLAKE_REF` and `FLK_PROFILE`, then reloads via direnv or `nix develop`
 - Reuses the saved profile cache until the environment definition changes
 
 **Notes**

--- a/flk-book/src/commands/hook.md
+++ b/flk-book/src/commands/hook.md
@@ -43,7 +43,8 @@ refresh
 ```
 
 - If direnv is present and `.envrc` exists, runs `direnv reload`
-- Otherwise, runs `nix develop` with the current profile
+- Otherwise, reuses a cached `nix develop` profile when it is still fresh
+- Rebuilds that cached profile when the flake inputs or relevant `.flk` files change
 - Uses the `FLK_FLAKE_REF` environment variable to determine the active profile
 
 ### `switch <profile>`
@@ -57,6 +58,7 @@ switch frontend
 
 - Validates the profile name before switching
 - Updates `FLK_FLAKE_REF` and reloads via direnv or `nix develop`
+- Reuses the saved profile cache until the environment definition changes
 
 **Notes**
 - The hook integrates with direnv automatically — if `.envrc` is present, it uses `direnv reload` instead of `exec nix develop`

--- a/flk-book/src/commands/switch.md
+++ b/flk-book/src/commands/switch.md
@@ -32,7 +32,8 @@ refresh
 
 **Behavior**
 - With direnv: runs `direnv reload`
-- Without direnv: runs `exec nix develop` with the current profile (replaces the shell process)
+- Without direnv: reuses a saved `nix develop` profile when it is current
+- Without direnv: refreshes that saved profile when the environment definition changes
 - Reads the active profile from `FLK_FLAKE_REF` environment variable
 
 ## `switch <profile>`
@@ -47,7 +48,7 @@ switch frontend
 **Behavior**
 - Validates the profile name (alphanumeric, `-`, `_` only)
 - Sets `FLK_FLAKE_REF` to the new profile reference
-- Reloads via direnv or `nix develop` as appropriate
+- Reloads via direnv or `nix develop` as appropriate, reusing the saved profile cache when possible
 
 ## Direnv Integration
 

--- a/flk-book/src/commands/switch.md
+++ b/flk-book/src/commands/switch.md
@@ -34,7 +34,7 @@ refresh
 - With direnv: runs `direnv reload`
 - Without direnv: reuses a saved `nix develop` profile when it is current
 - Without direnv: refreshes that saved profile when the environment definition changes
-- Reads the active profile from `FLK_FLAKE_REF` environment variable
+- Reads the active profile from `FLK_FLAKE_REF` (fallback: `FLK_PROFILE`)
 
 ## `switch <profile>`
 
@@ -47,7 +47,7 @@ switch frontend
 
 **Behavior**
 - Validates the profile name (alphanumeric, `-`, `_` only)
-- Sets `FLK_FLAKE_REF` to the new profile reference
+- Sets `FLK_FLAKE_REF` and `FLK_PROFILE` to the new profile reference
 - Reloads via direnv or `nix develop` as appropriate, reusing the saved profile cache when possible
 
 ## Direnv Integration

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -129,7 +129,7 @@ fn profile_cache_is_fresh(profile: &str, profile_path: &Path, stamp_path: &Path)
                 format!("Failed to read modification time for '{}'", path.display())
             })?;
 
-        if modified > stamp_modified {
+        if modified >= stamp_modified {
             return Ok(false);
         }
     }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -122,7 +122,7 @@ fn profile_cache_is_fresh(profile: &str, profile_path: &Path, stamp_path: &Path)
                 format!("Failed to read modification time for '{}'", path.display())
             })?;
 
-        if modified >= stamp_modified {
+        if modified > stamp_modified {
             return Ok(false);
         }
     }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -67,7 +67,7 @@ pub fn run_activate(current_profile: Option<String>) -> Result<()> {
         cmd.arg(
             "if [ -e \"$FLK_PROFILE_PATH\" ]; then \
              mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; \
-             touch \"$FLK_PROFILE_STAMP\"; \
+             touch \"$FLK_PROFILE_STAMP\" || exit 1; \
              fi; \
              exec \"$FLK_SHELL_CMD\"",
         );

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -2,6 +2,7 @@
 //!
 //! Enter the Nix development shell for the current flake.
 
+use crate::commands::profile_cache::profile_cache_inputs;
 use anyhow::{Context, Result};
 use colored::Colorize;
 use flk::flake::parsers::utils::resolve_profile;
@@ -10,14 +11,6 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
 };
-
-const PROFILE_CACHE_INPUTS: [&str; 5] = [
-    "flake.nix",
-    "flake.lock",
-    ".flk/default.nix",
-    ".flk/pins.nix",
-    ".flk/overlays.nix",
-];
 
 /// Enter the Nix development shell for the resolved profile.
 ///
@@ -135,13 +128,4 @@ fn profile_cache_is_fresh(profile: &str, profile_path: &Path, stamp_path: &Path)
     }
 
     Ok(true)
-}
-
-fn profile_cache_inputs(profile: &str) -> Vec<PathBuf> {
-    let mut paths = PROFILE_CACHE_INPUTS
-        .iter()
-        .map(PathBuf::from)
-        .collect::<Vec<_>>();
-    paths.push(Path::new(".flk/profiles").join(format!("{profile}.nix")));
-    paths
 }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -122,6 +122,8 @@ fn profile_cache_is_fresh(profile: &str, profile_path: &Path, stamp_path: &Path)
                 format!("Failed to read modification time for '{}'", path.display())
             })?;
 
+        // Treat equal mtimes as fresh — the stamp is written after a successful
+        // build, so inputs touched in the same clock tick were already incorporated.
         if modified > stamp_modified {
             return Ok(false);
         }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -54,9 +54,24 @@ pub fn run_activate(current_profile: Option<String>) -> Result<()> {
     if !use_cached_profile {
         cmd.arg("--profile");
         cmd.arg(&profile_path);
+        cmd.env("FLK_PROFILE_PATH", &profile_path);
+        cmd.env("FLK_PROFILE_STAMP", &stamp_path);
+        cmd.env("FLK_SHELL_CMD", &shell);
     }
     cmd.arg("-c");
-    cmd.arg(shell);
+    if use_cached_profile {
+        cmd.arg(shell);
+    } else {
+        cmd.arg("/bin/sh");
+        cmd.arg("-c");
+        cmd.arg(
+            "if [ -e \"$FLK_PROFILE_PATH\" ]; then \
+             mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; \
+             touch \"$FLK_PROFILE_STAMP\"; \
+             fi; \
+             exec \"$FLK_SHELL_CMD\"",
+        );
+    }
 
     let status = cmd.status().with_context(|| {
         format!(
@@ -65,9 +80,6 @@ pub fn run_activate(current_profile: Option<String>) -> Result<()> {
         )
     })?;
     if status.success() {
-        if !use_cached_profile && profile_path.exists() {
-            refresh_profile_cache_stamp(&stamp_path)?;
-        }
         Ok(())
     } else {
         Err(anyhow::anyhow!(
@@ -132,13 +144,4 @@ fn profile_cache_inputs(profile: &str) -> Vec<PathBuf> {
         .collect::<Vec<_>>();
     paths.push(Path::new(".flk/profiles").join(format!("{profile}.nix")));
     paths
-}
-
-fn refresh_profile_cache_stamp(stamp_path: &Path) -> Result<()> {
-    fs::write(stamp_path, "").with_context(|| {
-        format!(
-            "Failed to update profile cache stamp '{}'",
-            stamp_path.display()
-        )
-    })
 }

--- a/src/commands/activate.rs
+++ b/src/commands/activate.rs
@@ -5,13 +5,25 @@
 use anyhow::{Context, Result};
 use colored::Colorize;
 use flk::flake::parsers::utils::resolve_profile;
-use std::env;
 use std::process::Command;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+const PROFILE_CACHE_INPUTS: [&str; 5] = [
+    "flake.nix",
+    "flake.lock",
+    ".flk/default.nix",
+    ".flk/pins.nix",
+    ".flk/overlays.nix",
+];
 
 /// Enter the Nix development shell for the resolved profile.
 ///
-/// Runs `nix develop` with `--impure` and GC root pinning for faster
-/// re-activation on subsequent runs.
+/// Reuses a cached `nix develop --profile` environment when the relevant flake
+/// files are unchanged, and refreshes that cache when the environment
+/// definition changes.
 ///
 /// # Arguments
 ///
@@ -24,18 +36,25 @@ pub fn run_activate(current_profile: Option<String>) -> Result<()> {
         profile.cyan()
     );
 
-    // Build nix develop command with GC root pinning for faster re-activation
-    let profile_path = format!(".flk/.nix-profile-{}", profile);
     let shell = env::var("SHELL")
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "/bin/sh".to_string());
+    let profile_path = profile_cache_path(&profile);
+    let stamp_path = profile_cache_stamp_path(&profile);
+    let use_cached_profile = profile_cache_is_fresh(&profile, &profile_path, &stamp_path)?;
     let mut cmd = Command::new("nix");
     cmd.arg("develop");
-    cmd.arg(format!(".#{}", profile));
+    if use_cached_profile {
+        cmd.arg(&profile_path);
+    } else {
+        cmd.arg(format!(".#{}", profile));
+    }
     cmd.arg("--impure");
-    cmd.arg("--profile");
-    cmd.arg(&profile_path);
+    if !use_cached_profile {
+        cmd.arg("--profile");
+        cmd.arg(&profile_path);
+    }
     cmd.arg("-c");
     cmd.arg(shell);
 
@@ -46,6 +65,9 @@ pub fn run_activate(current_profile: Option<String>) -> Result<()> {
         )
     })?;
     if status.success() {
+        if !use_cached_profile && profile_path.exists() {
+            refresh_profile_cache_stamp(&stamp_path)?;
+        }
         Ok(())
     } else {
         Err(anyhow::anyhow!(
@@ -53,4 +75,70 @@ pub fn run_activate(current_profile: Option<String>) -> Result<()> {
             status
         ))
     }
+}
+
+fn profile_cache_path(profile: &str) -> PathBuf {
+    Path::new(".flk").join(format!(".nix-profile-{profile}"))
+}
+
+fn profile_cache_stamp_path(profile: &str) -> PathBuf {
+    Path::new(".flk").join(format!(".nix-profile-{profile}.stamp"))
+}
+
+fn profile_cache_is_fresh(profile: &str, profile_path: &Path, stamp_path: &Path) -> Result<bool> {
+    if !profile_path.exists() || !stamp_path.exists() {
+        return Ok(false);
+    }
+
+    let stamp_modified = fs::metadata(stamp_path)
+        .with_context(|| {
+            format!(
+                "Failed to read metadata for profile cache stamp '{}'",
+                stamp_path.display()
+            )
+        })?
+        .modified()
+        .with_context(|| {
+            format!(
+                "Failed to read modification time for profile cache stamp '{}'",
+                stamp_path.display()
+            )
+        })?;
+
+    for path in profile_cache_inputs(profile) {
+        if !path.exists() {
+            continue;
+        }
+
+        let modified = fs::metadata(&path)
+            .with_context(|| format!("Failed to read metadata for '{}'", path.display()))?
+            .modified()
+            .with_context(|| {
+                format!("Failed to read modification time for '{}'", path.display())
+            })?;
+
+        if modified > stamp_modified {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn profile_cache_inputs(profile: &str) -> Vec<PathBuf> {
+    let mut paths = PROFILE_CACHE_INPUTS
+        .iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    paths.push(Path::new(".flk/profiles").join(format!("{profile}.nix")));
+    paths
+}
+
+fn refresh_profile_cache_stamp(stamp_path: &Path) -> Result<()> {
+    fs::write(stamp_path, "").with_context(|| {
+        format!(
+            "Failed to update profile cache stamp '{}'",
+            stamp_path.display()
+        )
+    })
 }

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -56,8 +56,9 @@ _flk_exec_nix_develop() {{
   else
     exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
       if [ -e "$FLK_PROFILE_PATH" ]; then
-        mkdir -p "$(dirname "$FLK_PROFILE_STAMP")"
-        touch "$FLK_PROFILE_STAMP"
+        mkdir -p "$(dirname "$FLK_PROFILE_STAMP")" &&
+        touch "$FLK_PROFILE_STAMP" ||
+        exit 1
       fi
       exec "$FLK_SHELL_CMD"
     '
@@ -147,8 +148,9 @@ function _flk_exec_nix_develop
   else
     exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
       if [ -e "$FLK_PROFILE_PATH" ]; then
-        mkdir -p "$(dirname "$FLK_PROFILE_STAMP")"
-        touch "$FLK_PROFILE_STAMP"
+        mkdir -p "$(dirname "$FLK_PROFILE_STAMP")" &&
+        touch "$FLK_PROFILE_STAMP" ||
+        exit 1
       fi
       exec "$FLK_SHELL_CMD"
     '

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -30,7 +30,7 @@ fn print_bash_like() {
     println!(
         r#"# flk hook: refresh/switch for direnv + nix develop
 _flk_use_direnv() {{ command -v direnv >/dev/null 2>&1 && [ -f .envrc ]; }}
-_flk_valid_profile() {{ [[ "$1" =~ ^[a-zA-Z0-9_+-]+$ ]]; }}
+_flk_valid_profile() {{ [[ "$1" =~ ^[a-zA-Z0-9_-]+$ ]]; }}
 _flk_profile_path() {{ printf '.flk/.nix-profile-%s' "$1"; }}
 _flk_profile_stamp() {{ printf '.flk/.nix-profile-%s.stamp' "$1"; }}
 _flk_profile_is_fresh() {{
@@ -66,12 +66,13 @@ _flk_exec_nix_develop() {{
 }}
 
 refresh() {{
-  local _flk_ref="${{FLK_FLAKE_REF:-.#default}}"
+  local _flk_ref="${{FLK_FLAKE_REF:-${{FLK_PROFILE:-.#default}}}}"
   local _flk_profile_name="${{_flk_ref##*.#}}"
   if ! _flk_valid_profile "$_flk_profile_name"; then
     printf 'invalid profile name: %s\n' "$_flk_profile_name" >&2
     return 1
   fi
+  export FLK_FLAKE_REF="$_flk_ref"
   export FLK_PROFILE="$_flk_ref"
   if _flk_use_direnv; then
     direnv reload
@@ -91,9 +92,10 @@ switch() {{
     return 1
   fi
   if _flk_use_direnv; then
-     export FLK_PROFILE=".#$profile"
-     direnv reload
-   else
+      export FLK_FLAKE_REF=".#$profile"
+      export FLK_PROFILE=".#$profile"
+      direnv reload
+    else
     _flk_exec_nix_develop ".#$profile" "$profile" "${{SHELL:-/bin/sh}}"
   fi
 }}
@@ -109,7 +111,7 @@ function _flk_use_direnv
 end
 
 function _flk_valid_profile
-  string match -qr '^[a-zA-Z0-9_+-]+$' -- $argv[1]
+  string match -qr '^[a-zA-Z0-9_-]+$' -- $argv[1]
 end
 
 function _flk_profile_path
@@ -153,16 +155,17 @@ function _flk_exec_nix_develop
 end
 
 function refresh --description "Reload env (direnv if present, else nix develop)"
+  set -l flk_ref (test -n "$FLK_FLAKE_REF"; and echo "$FLK_FLAKE_REF"; or test -n "$FLK_PROFILE"; and echo "$FLK_PROFILE"; or echo ".#default")
+  set -l profile_name (string replace -r '.*\\.#' '' "$flk_ref")
+  if not _flk_valid_profile "$profile_name"
+    echo "invalid profile name: $profile_name" 1>&2
+    return 1
+  end
   if _flk_use_direnv
-    set -lx FLK_PROFILE "$FLK_FLAKE_REF"
+    set -lx FLK_FLAKE_REF "$flk_ref"
+    set -lx FLK_PROFILE "$flk_ref"
     direnv reload
   else
-    set -l flk_ref (test -n "$FLK_FLAKE_REF"; and echo "$FLK_FLAKE_REF"; or echo ".#default")
-    set -l profile_name (string replace -r '.*\\.#' '' "$flk_ref")
-    if not _flk_valid_profile "$profile_name"
-      echo "invalid profile name: $profile_name" 1>&2
-      return 1
-    end
     set -l flk_shell (test -n "$SHELL"; and echo "$SHELL"; or echo "/bin/sh")
     _flk_exec_nix_develop "$flk_ref" "$profile_name" "$flk_shell"
   end
@@ -179,6 +182,7 @@ function switch --description "Switch profile and reload"
     return 1
   end
   if _flk_use_direnv
+    set -lx FLK_FLAKE_REF ".#$profile"
     set -lx FLK_PROFILE ".#$profile"
     direnv reload
   else

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -31,6 +31,39 @@ fn print_bash_like() {
         r#"# flk hook: refresh/switch for direnv + nix develop
 _flk_use_direnv() {{ command -v direnv >/dev/null 2>&1 && [ -f .envrc ]; }}
 _flk_valid_profile() {{ [[ "$1" =~ ^[a-zA-Z0-9_+-]+$ ]]; }}
+_flk_profile_path() {{ printf '.flk/.nix-profile-%s' "$1"; }}
+_flk_profile_stamp() {{ printf '.flk/.nix-profile-%s.stamp' "$1"; }}
+_flk_profile_is_fresh() {{
+  local profile="$1"
+  local profile_path="$(_flk_profile_path "$profile")"
+  local stamp_path="$(_flk_profile_stamp "$profile")"
+  local f
+  [ -e "$profile_path" ] && [ -e "$stamp_path" ] || return 1
+  for f in "flake.nix" "flake.lock" ".flk/default.nix" ".flk/pins.nix" ".flk/overlays.nix" ".flk/profiles/$profile.nix"; do
+    [ -e "$f" ] || continue
+    [ "$f" -nt "$stamp_path" ] && return 1
+  done
+  return 0
+}}
+_flk_exec_nix_develop() {{
+  local ref="$1"
+  local profile="$2"
+  local flk_shell="$3"
+  local profile_path="$(_flk_profile_path "$profile")"
+  local stamp_path="$(_flk_profile_stamp "$profile")"
+  if _flk_profile_is_fresh "$profile"; then
+    exec nix develop "$profile_path" --impure -c "$flk_shell"
+  else
+    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" /bin/sh -c '
+      nix develop "$FLK_REF" --impure --profile "$FLK_PROFILE_PATH" -c "$FLK_SHELL_CMD"
+      status=$?
+      if [ "$status" -eq 0 ] && [ -e "$FLK_PROFILE_PATH" ]; then
+        touch "$FLK_PROFILE_STAMP"
+      fi
+      exit "$status"
+    '
+  fi
+}}
 
 refresh() {{
   local _flk_ref="${{FLK_FLAKE_REF:-.#default}}"
@@ -43,7 +76,7 @@ refresh() {{
   if _flk_use_direnv; then
     direnv reload
   else
-    exec nix develop "$_flk_ref" --impure --profile ".flk/.nix-profile-$_flk_profile_name" -c "${{SHELL:-/bin/sh}}"
+    _flk_exec_nix_develop "$_flk_ref" "$_flk_profile_name" "${{SHELL:-/bin/sh}}"
   fi
 }}
 
@@ -60,9 +93,9 @@ switch() {{
   if _flk_use_direnv; then
      export FLK_PROFILE=".#$profile"
      direnv reload
-  else
-    exec nix develop ".#$profile" --impure --profile ".flk/.nix-profile-$profile" -c "${{SHELL:-/bin/sh}}"
- fi
+   else
+    _flk_exec_nix_develop ".#$profile" "$profile" "${{SHELL:-/bin/sh}}"
+  fi
 }}
 "#
     );
@@ -79,6 +112,46 @@ function _flk_valid_profile
   string match -qr '^[a-zA-Z0-9_+-]+$' -- $argv[1]
 end
 
+function _flk_profile_path
+  printf '.flk/.nix-profile-%s' $argv[1]
+end
+
+function _flk_profile_stamp
+  printf '.flk/.nix-profile-%s.stamp' $argv[1]
+end
+
+function _flk_profile_is_fresh
+  set profile $argv[1]
+  set profile_path (_flk_profile_path "$profile")
+  set stamp_path (_flk_profile_stamp "$profile")
+  test -e "$profile_path"; and test -e "$stamp_path"; or return 1
+  for f in "flake.nix" "flake.lock" ".flk/default.nix" ".flk/pins.nix" ".flk/overlays.nix" ".flk/profiles/$profile.nix"
+    test -e "$f"; or continue
+    test "$f" -nt "$stamp_path"; and return 1
+  end
+  return 0
+end
+
+function _flk_exec_nix_develop
+  set ref $argv[1]
+  set profile $argv[2]
+  set flk_shell $argv[3]
+  set profile_path (_flk_profile_path "$profile")
+  set stamp_path (_flk_profile_stamp "$profile")
+  if _flk_profile_is_fresh "$profile"
+    exec nix develop "$profile_path" --impure -c "$flk_shell"
+  else
+    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" /bin/sh -c '
+      nix develop "$FLK_REF" --impure --profile "$FLK_PROFILE_PATH" -c "$FLK_SHELL_CMD"
+      status=$?
+      if [ "$status" -eq 0 ] && [ -e "$FLK_PROFILE_PATH" ]; then
+        touch "$FLK_PROFILE_STAMP"
+      fi
+      exit "$status"
+    '
+  end
+end
+
 function refresh --description "Reload env (direnv if present, else nix develop)"
   if _flk_use_direnv
     set -lx FLK_PROFILE "$FLK_FLAKE_REF"
@@ -91,7 +164,7 @@ function refresh --description "Reload env (direnv if present, else nix develop)
       return 1
     end
     set -l flk_shell (test -n "$SHELL"; and echo "$SHELL"; or echo "/bin/sh")
-    exec nix develop "$flk_ref" --impure --profile ".flk/.nix-profile-$profile_name" -c "$flk_shell"
+    _flk_exec_nix_develop "$flk_ref" "$profile_name" "$flk_shell"
   end
 end
 
@@ -110,7 +183,7 @@ function switch --description "Switch profile and reload"
     direnv reload
   else
     set -l flk_shell (test -n "$SHELL"; and echo "$SHELL"; or echo "/bin/sh")
-    exec nix develop ".#$profile" --impure --profile ".flk/.nix-profile-$profile" -c "$flk_shell"
+    _flk_exec_nix_develop ".#$profile" "$profile" "$flk_shell"
   end
 end
 "#

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -93,10 +93,10 @@ switch() {{
     return 1
   fi
   if _flk_use_direnv; then
-      export FLK_FLAKE_REF=".#$profile"
-      export FLK_PROFILE=".#$profile"
-      direnv reload
-    else
+    export FLK_FLAKE_REF=".#$profile"
+    export FLK_PROFILE=".#$profile"
+    direnv reload
+  else
     export FLK_FLAKE_REF=".#$profile"
     export FLK_PROFILE=".#$profile"
     _flk_exec_nix_develop ".#$profile" "$profile" "${{SHELL:-/bin/sh}}"

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -41,7 +41,7 @@ _flk_profile_is_fresh() {{
   [ -e "$profile_path" ] && [ -e "$stamp_path" ] || return 1
   for f in "flake.nix" "flake.lock" ".flk/default.nix" ".flk/pins.nix" ".flk/overlays.nix" ".flk/profiles/$profile.nix"; do
     [ -e "$f" ] || continue
-    [ "$f" -nt "$stamp_path" ] && return 1
+    [ "$stamp_path" -nt "$f" ] || return 1
   done
   return 0
 }}
@@ -132,7 +132,7 @@ function _flk_profile_is_fresh
   test -e "$profile_path"; and test -e "$stamp_path"; or return 1
   for f in "flake.nix" "flake.lock" ".flk/default.nix" ".flk/pins.nix" ".flk/overlays.nix" ".flk/profiles/$profile.nix"
     test -e "$f"; or continue
-    test "$f" -nt "$stamp_path"; and return 1
+    test "$stamp_path" -nt "$f"; or return 1
   end
   return 0
 end

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -165,9 +165,9 @@ function refresh --description "Reload env (direnv if present, else nix develop)
     echo "invalid profile name: $profile_name" 1>&2
     return 1
   end
+  set -gx FLK_FLAKE_REF "$flk_ref"
+  set -gx FLK_PROFILE "$flk_ref"
   if _flk_use_direnv
-    set -lx FLK_FLAKE_REF "$flk_ref"
-    set -lx FLK_PROFILE "$flk_ref"
     direnv reload
   else
     set -l flk_shell (test -n "$SHELL"; and echo "$SHELL"; or echo "/bin/sh")
@@ -185,13 +185,11 @@ function switch --description "Switch profile and reload"
     echo "invalid profile name: $profile" 1>&2
     return 1
   end
+  set -gx FLK_FLAKE_REF ".#$profile"
+  set -gx FLK_PROFILE ".#$profile"
   if _flk_use_direnv
-    set -lx FLK_FLAKE_REF ".#$profile"
-    set -lx FLK_PROFILE ".#$profile"
     direnv reload
   else
-    set -lx FLK_FLAKE_REF ".#$profile"
-    set -lx FLK_PROFILE ".#$profile"
     set -l flk_shell (test -n "$SHELL"; and echo "$SHELL"; or echo "/bin/sh")
     _flk_exec_nix_develop ".#$profile" "$profile" "$flk_shell"
   end

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -54,7 +54,7 @@ _flk_exec_nix_develop() {{
   if _flk_profile_is_fresh "$profile"; then
     exec nix develop "$profile_path" --impure -c "$flk_shell"
   else
-    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
+    exec env FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
       if [ -e "$FLK_PROFILE_PATH" ]; then
         mkdir -p "$(dirname "$FLK_PROFILE_STAMP")" &&
         touch "$FLK_PROFILE_STAMP" ||
@@ -146,7 +146,7 @@ function _flk_exec_nix_develop
   if _flk_profile_is_fresh "$profile"
     exec nix develop "$profile_path" --impure -c "$flk_shell"
   else
-    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
+    exec env FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
       if [ -e "$FLK_PROFILE_PATH" ]; then
         mkdir -p "$(dirname "$FLK_PROFILE_STAMP")" &&
         touch "$FLK_PROFILE_STAMP" ||

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -3,6 +3,7 @@
 //! Generate shell hooks for bash, zsh, and fish that enable the
 //! `refresh` and `switch` commands for hot-reloading environments.
 
+use crate::commands::profile_cache::profile_cache_hook_inputs;
 use anyhow::Result;
 use clap::ValueEnum;
 
@@ -27,6 +28,7 @@ pub fn run_hook(shell: HookShell) -> Result<()> {
 }
 
 fn print_bash_like() {
+    let cache_inputs = profile_cache_hook_inputs("$profile");
     println!(
         r#"# flk hook: refresh/switch for direnv + nix develop
 _flk_use_direnv() {{ command -v direnv >/dev/null 2>&1 && [ -f .envrc ]; }}
@@ -39,7 +41,7 @@ _flk_profile_is_fresh() {{
   local stamp_path="$(_flk_profile_stamp "$profile")"
   local f
   [ -e "$profile_path" ] && [ -e "$stamp_path" ] || return 1
-  for f in "flake.nix" "flake.lock" ".flk/default.nix" ".flk/pins.nix" ".flk/overlays.nix" ".flk/profiles/$profile.nix"; do
+  for f in {cache_inputs}; do
     [ -e "$f" ] || continue
     [ "$stamp_path" -nt "$f" ] || return 1
   done
@@ -102,11 +104,13 @@ switch() {{
     _flk_exec_nix_develop ".#$profile" "$profile" "${{SHELL:-/bin/sh}}"
   fi
 }}
-"#
+"#,
+        cache_inputs = cache_inputs
     );
 }
 
 fn print_fish() {
+    let cache_inputs = profile_cache_hook_inputs("$profile");
     println!(
         r#"# flk hook: refresh/switch for direnv + nix develop (fish)
 function _flk_use_direnv
@@ -130,7 +134,7 @@ function _flk_profile_is_fresh
   set profile_path (_flk_profile_path "$profile")
   set stamp_path (_flk_profile_stamp "$profile")
   test -e "$profile_path"; and test -e "$stamp_path"; or return 1
-  for f in "flake.nix" "flake.lock" ".flk/default.nix" ".flk/pins.nix" ".flk/overlays.nix" ".flk/profiles/$profile.nix"
+  for f in {cache_inputs}
     test -e "$f"; or continue
     test "$stamp_path" -nt "$f"; or return 1
   end
@@ -194,6 +198,7 @@ function switch --description "Switch profile and reload"
     _flk_exec_nix_develop ".#$profile" "$profile" "$flk_shell"
   end
 end
-"#
+"#,
+        cache_inputs = cache_inputs
     );
 }

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -66,6 +66,7 @@ _flk_exec_nix_develop() {{
 }}
 
 refresh() {{
+  # Fallback order: FLK_FLAKE_REF -> FLK_PROFILE -> .#default
   local _flk_ref="${{FLK_FLAKE_REF:-${{FLK_PROFILE:-.#default}}}}"
   local _flk_profile_name="${{_flk_ref##*.#}}"
   if ! _flk_valid_profile "$_flk_profile_name"; then
@@ -155,6 +156,7 @@ function _flk_exec_nix_develop
 end
 
 function refresh --description "Reload env (direnv if present, else nix develop)"
+  # Fallback order: FLK_FLAKE_REF -> FLK_PROFILE -> .#default
   set -l flk_ref (test -n "$FLK_FLAKE_REF"; and echo "$FLK_FLAKE_REF"; or test -n "$FLK_PROFILE"; and echo "$FLK_PROFILE"; or echo ".#default")
   set -l profile_name (string replace -r '.*\\.#' '' "$flk_ref")
   if not _flk_valid_profile "$profile_name"

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -40,7 +40,7 @@ _flk_profile_is_fresh() {{
   local profile_path="$(_flk_profile_path "$profile")"
   local stamp_path="$(_flk_profile_stamp "$profile")"
   local f
-  [ -e "$profile_path" ] && [ -e "$stamp_path" ] || return 1
+  if [ ! -e "$profile_path" ] || [ ! -e "$stamp_path" ]; then return 1; fi
   for f in {cache_inputs}; do
     [ -e "$f" ] || continue
     [ "$f" -nt "$stamp_path" ] && return 1

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -43,7 +43,7 @@ _flk_profile_is_fresh() {{
   [ -e "$profile_path" ] && [ -e "$stamp_path" ] || return 1
   for f in {cache_inputs}; do
     [ -e "$f" ] || continue
-    [ "$stamp_path" -nt "$f" ] || return 1
+    [ "$f" -nt "$stamp_path" ] && return 1
   done
   return 0
 }}
@@ -136,7 +136,7 @@ function _flk_profile_is_fresh
   test -e "$profile_path"; and test -e "$stamp_path"; or return 1
   for f in {cache_inputs}
     test -e "$f"; or continue
-    test "$stamp_path" -nt "$f"; or return 1
+    test "$f" -nt "$stamp_path"; and return 1
   end
   return 0
 end

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -54,13 +54,12 @@ _flk_exec_nix_develop() {{
   if _flk_profile_is_fresh "$profile"; then
     exec nix develop "$profile_path" --impure -c "$flk_shell"
   else
-    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" /bin/sh -c '
-      nix develop "$FLK_REF" --impure --profile "$FLK_PROFILE_PATH" -c "$FLK_SHELL_CMD"
-      status=$?
-      if [ "$status" -eq 0 ] && [ -e "$FLK_PROFILE_PATH" ]; then
+    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
+      if [ -e "$FLK_PROFILE_PATH" ]; then
+        mkdir -p "$(dirname "$FLK_PROFILE_STAMP")"
         touch "$FLK_PROFILE_STAMP"
       fi
-      exit "$status"
+      exec "$FLK_SHELL_CMD"
     '
   fi
 }}
@@ -97,6 +96,8 @@ switch() {{
       export FLK_PROFILE=".#$profile"
       direnv reload
     else
+    export FLK_FLAKE_REF=".#$profile"
+    export FLK_PROFILE=".#$profile"
     _flk_exec_nix_develop ".#$profile" "$profile" "${{SHELL:-/bin/sh}}"
   fi
 }}
@@ -144,13 +145,12 @@ function _flk_exec_nix_develop
   if _flk_profile_is_fresh "$profile"
     exec nix develop "$profile_path" --impure -c "$flk_shell"
   else
-    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" /bin/sh -c '
-      nix develop "$FLK_REF" --impure --profile "$FLK_PROFILE_PATH" -c "$FLK_SHELL_CMD"
-      status=$?
-      if [ "$status" -eq 0 ] && [ -e "$FLK_PROFILE_PATH" ]; then
+    exec env FLK_REF="$ref" FLK_PROFILE_PATH="$profile_path" FLK_SHELL_CMD="$flk_shell" FLK_PROFILE_STAMP="$stamp_path" nix develop "$ref" --impure --profile "$profile_path" -c /bin/sh -c '
+      if [ -e "$FLK_PROFILE_PATH" ]; then
+        mkdir -p "$(dirname "$FLK_PROFILE_STAMP")"
         touch "$FLK_PROFILE_STAMP"
       fi
-      exit "$status"
+      exec "$FLK_SHELL_CMD"
     '
   end
 end
@@ -188,6 +188,8 @@ function switch --description "Switch profile and reload"
     set -lx FLK_PROFILE ".#$profile"
     direnv reload
   else
+    set -lx FLK_FLAKE_REF ".#$profile"
+    set -lx FLK_PROFILE ".#$profile"
     set -l flk_shell (test -n "$SHELL"; and echo "$SHELL"; or echo "/bin/sh")
     _flk_exec_nix_develop ".#$profile" "$profile" "$flk_shell"
   end

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub mod hook;
 pub mod init;
 pub mod list;
 pub mod lock;
+pub mod profile_cache;
 pub mod profiles;
 pub mod remove;
 pub mod search;

--- a/src/commands/profile_cache.rs
+++ b/src/commands/profile_cache.rs
@@ -1,0 +1,29 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) const PROFILE_CACHE_INPUTS: [&str; 5] = [
+    "flake.nix",
+    "flake.lock",
+    ".flk/default.nix",
+    ".flk/pins.nix",
+    ".flk/overlays.nix",
+];
+
+pub(crate) fn profile_cache_inputs(profile: &str) -> Vec<PathBuf> {
+    let mut paths = PROFILE_CACHE_INPUTS
+        .iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    paths.push(Path::new(".flk/profiles").join(format!("{profile}.nix")));
+    paths
+}
+
+pub(crate) fn profile_cache_hook_inputs(profile_expr: &str) -> String {
+    PROFILE_CACHE_INPUTS
+        .iter()
+        .map(|path| format!("\"{path}\""))
+        .chain(std::iter::once(format!(
+            "\".flk/profiles/{profile_expr}.nix\""
+        )))
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/src/commands/profile_cache.rs
+++ b/src/commands/profile_cache.rs
@@ -17,6 +17,10 @@ pub(crate) fn profile_cache_inputs(profile: &str) -> Vec<PathBuf> {
     paths
 }
 
+/// Generate a space-separated list of quoted cache-input paths for shell `for` loops.
+///
+/// `profile_expr` should be a shell variable reference (e.g. `"$profile"`) so it is
+/// expanded at runtime by the target shell.
 pub(crate) fn profile_cache_hook_inputs(profile_expr: &str) -> String {
     PROFILE_CACHE_INPUTS
         .iter()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -41,9 +41,19 @@ fn set_modified_time(path: &Path, modified: std::time::SystemTime) {
 }
 
 #[cfg(unix)]
-fn nix_available() -> bool {
+fn real_nix_tests_enabled() -> bool {
+    if env::var("RUN_REAL_NIX_TESTS").as_deref() != Ok("1") {
+        return false;
+    }
+
     std::process::Command::new("nix")
-        .arg("--version")
+        .args([
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "flake",
+            "metadata",
+            "--help",
+        ])
         .status()
         .map(|status| status.success())
         .unwrap_or(false)
@@ -517,6 +527,7 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
         .stdout(contains("export FLK_PROFILE=\".#$profile\""))
         .stdout(contains("_flk_exec_nix_develop \".#$profile\""))
+        .stdout(contains("[ \"$stamp_path\" -nt \"$f\" ] || return 1"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -530,6 +541,7 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
         .stdout(contains("export FLK_PROFILE=\".#$profile\""))
         .stdout(contains("_flk_exec_nix_develop \".#$profile\""))
+        .stdout(contains("[ \"$stamp_path\" -nt \"$f\" ] || return 1"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -546,6 +558,7 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("set -gx FLK_FLAKE_REF"))
         .stdout(contains("set -gx FLK_PROFILE"))
         .stdout(contains("set -l flk_shell"))
+        .stdout(contains("test \"$stamp_path\" -nt \"$f\"; or return 1"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 }
@@ -659,8 +672,10 @@ fn test_activate_reuses_fresh_profile_cache() {
 #[cfg(unix)]
 #[test]
 fn test_activate_profile_cache_with_real_nix_when_available() {
-    if !nix_available() {
-        eprintln!("skipping test_activate_profile_cache_with_real_nix_when_available: `nix` not available");
+    if !real_nix_tests_enabled() {
+        eprintln!(
+            "skipping test_activate_profile_cache_with_real_nix_when_available: set RUN_REAL_NIX_TESTS=1 and ensure nix flakes support is available"
+        );
         return;
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -637,6 +637,22 @@ fn test_activate_reuses_fresh_profile_cache() {
 
     fs::write(&profile_path, "cached-profile").unwrap();
     fs::write(&stamp_path, "").unwrap();
+    let tracked_input_mtime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1);
+    for input in [
+        "flake.nix",
+        "flake.lock",
+        ".flk/default.nix",
+        ".flk/pins.nix",
+        ".flk/overlays.nix",
+        ".flk/profiles/generic.nix",
+    ] {
+        let input_path = temp_dir.path().join(input);
+        if input_path.exists() {
+            set_modified_time(&input_path, tracked_input_mtime);
+        }
+    }
+    let fresh_stamp_mtime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(2);
+    set_modified_time(&stamp_path, fresh_stamp_mtime);
 
     flk_cmd()
         .current_dir(temp_dir.path())
@@ -727,10 +743,9 @@ fn test_activate_profile_cache_with_real_nix_when_available() {
         format!("{original_flake}\n# force cache refresh\n"),
     )
     .unwrap();
-    set_modified_time(
-        &flake_path,
-        std::time::SystemTime::now() + std::time::Duration::from_secs(2),
-    );
+    // Force a stale stamp timestamp so tracked inputs are always newer.
+    let stale_stamp_mtime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1);
+    set_modified_time(&stamp_path, stale_stamp_mtime);
 
     flk_cmd()
         .current_dir(temp_dir.path())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -529,8 +529,8 @@ fn test_hook_shells_include_shell_command() {
         ))
         .stdout(contains("-c \"$flk_shell\""))
         .stdout(contains("exec \"$FLK_SHELL_CMD\""))
-        .stdout(contains("set -lx FLK_FLAKE_REF \".#$profile\""))
-        .stdout(contains("set -lx FLK_PROFILE \".#$profile\""))
+        .stdout(contains("set -gx FLK_FLAKE_REF"))
+        .stdout(contains("set -gx FLK_PROFILE"))
         .stdout(contains("set -l flk_shell"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -682,7 +682,7 @@ fn test_activate_reuses_fresh_profile_cache() {
 
 #[cfg(unix)]
 #[test]
-fn test_activate_reuses_cache_when_stamp_equals_input_mtime() {
+fn test_activate_treats_cache_fresh_when_stamp_equals_input_mtime() {
     let temp_dir = TempDir::new().unwrap();
     let fake_bin_dir = temp_dir.path().join("bin");
     let fake_nix_path = fake_bin_dir.join("nix");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -47,15 +47,8 @@ fn real_nix_tests_enabled() -> bool {
     }
 
     std::process::Command::new("nix")
-        .args([
-            "--extra-experimental-features",
-            "nix-command",
-            "--extra-experimental-features",
-            "flakes",
-            "flake",
-            "metadata",
-            "--help",
-        ])
+        .env("NIX_CONFIG", "experimental-features = nix-command flakes")
+        .args(["flake", "metadata", "--help"])
         .status()
         .map(|status| status.success())
         .unwrap_or(false)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -477,13 +477,17 @@ fn test_hook_shells_include_shell_command() {
         .args(["hook", "bash"])
         .assert()
         .success()
-        .stdout(contains("-c \"${SHELL:-/bin/sh}\""));
+        .stdout(contains("\"${SHELL:-/bin/sh}\""))
+        .stdout(contains(".nix-profile-"))
+        .stdout(contains(".stamp"));
 
     flk_cmd()
         .args(["hook", "zsh"])
         .assert()
         .success()
-        .stdout(contains("-c \"${SHELL:-/bin/sh}\""));
+        .stdout(contains("\"${SHELL:-/bin/sh}\""))
+        .stdout(contains(".nix-profile-"))
+        .stdout(contains(".stamp"));
 
     flk_cmd()
         .args(["hook", "fish"])
@@ -492,7 +496,9 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains(
             "set -l flk_shell (test -n \"$SHELL\"; and echo \"$SHELL\"; or echo \"/bin/sh\")",
         ))
-        .stdout(contains("-c \"$flk_shell\""));
+        .stdout(contains("-c \"$flk_shell\""))
+        .stdout(contains(".nix-profile-"))
+        .stdout(contains(".stamp"));
 }
 
 #[cfg(unix)]
@@ -526,6 +532,122 @@ fn test_activate_uses_shell_fallback_and_profile_gc_root() {
         .assert()
         .success()
         .stdout(contains("Activating nix develop shell with profile:"));
+
+    let args: Vec<String> = fs::read_to_string(&log_path)
+        .unwrap()
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect();
+    assert_eq!(
+        args,
+        vec![
+            "develop",
+            ".#generic",
+            "--impure",
+            "--profile",
+            ".flk/.nix-profile-generic",
+            "-c",
+            "/bin/sh",
+        ]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_activate_reuses_fresh_profile_cache() {
+    let temp_dir = TempDir::new().unwrap();
+    let fake_bin_dir = temp_dir.path().join("bin");
+    let fake_nix_path = fake_bin_dir.join("nix");
+    let log_path = temp_dir.path().join("nix-args.log");
+    let profile_path = temp_dir.path().join(".flk/.nix-profile-generic");
+    let stamp_path = temp_dir.path().join(".flk/.nix-profile-generic.stamp");
+
+    fs::create_dir_all(&fake_bin_dir).unwrap();
+    fs::write(
+        &fake_nix_path,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FAKE_NIX_LOG\"\n",
+    )
+    .unwrap();
+    make_executable(&fake_nix_path);
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    fs::write(&profile_path, "cached-profile").unwrap();
+    fs::write(&stamp_path, "").unwrap();
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .env("PATH", prepend_path(&fake_bin_dir))
+        .env("FAKE_NIX_LOG", &log_path)
+        .env_remove("SHELL")
+        .args(["activate", "--profile", "generic"])
+        .assert()
+        .success();
+
+    let args: Vec<String> = fs::read_to_string(&log_path)
+        .unwrap()
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect();
+    assert_eq!(
+        args,
+        vec![
+            "develop",
+            ".flk/.nix-profile-generic",
+            "--impure",
+            "-c",
+            "/bin/sh",
+        ]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_activate_refreshes_stale_profile_cache() {
+    let temp_dir = TempDir::new().unwrap();
+    let fake_bin_dir = temp_dir.path().join("bin");
+    let fake_nix_path = fake_bin_dir.join("nix");
+    let log_path = temp_dir.path().join("nix-args.log");
+    let profile_path = temp_dir.path().join(".flk/.nix-profile-generic");
+    let stamp_path = temp_dir.path().join(".flk/.nix-profile-generic.stamp");
+    let profile_file = temp_dir.path().join(".flk/profiles/generic.nix");
+
+    fs::create_dir_all(&fake_bin_dir).unwrap();
+    fs::write(
+        &fake_nix_path,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FAKE_NIX_LOG\"\n",
+    )
+    .unwrap();
+    make_executable(&fake_nix_path);
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    fs::write(&profile_path, "cached-profile").unwrap();
+    fs::write(&stamp_path, "").unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    fs::write(
+        &profile_file,
+        fs::read_to_string(&profile_file).unwrap() + "\n# stale\n",
+    )
+    .unwrap();
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .env("PATH", prepend_path(&fake_bin_dir))
+        .env("FAKE_NIX_LOG", &log_path)
+        .env_remove("SHELL")
+        .args(["activate", "--profile", "generic"])
+        .assert()
+        .success();
 
     let args: Vec<String> = fs::read_to_string(&log_path)
         .unwrap()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -49,6 +49,20 @@ fn nix_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Return the absolute path to the `true` binary.
+///
+/// macOS does not have `/bin/true` (it lives under `/usr/bin/true`), so we
+/// resolve it at runtime to keep the test portable across Linux and macOS.
+#[cfg(unix)]
+fn true_binary() -> String {
+    for candidate in &["/usr/bin/true", "/bin/true"] {
+        if Path::new(candidate).exists() {
+            return candidate.to_string();
+        }
+    }
+    panic!("could not find `true` binary on this system");
+}
+
 #[test]
 fn test_version() {
     flk_cmd()
@@ -660,9 +674,11 @@ fn test_activate_profile_cache_with_real_nix_when_available() {
         .assert()
         .success();
 
+    let true_bin = true_binary();
+
     flk_cmd()
         .current_dir(temp_dir.path())
-        .env("SHELL", "/bin/true")
+        .env("SHELL", &true_bin)
         .args(["activate", "--profile", "generic"])
         .assert()
         .success();
@@ -683,7 +699,7 @@ fn test_activate_profile_cache_with_real_nix_when_available() {
     // Second activation should reuse the cached profile (stamp unchanged).
     flk_cmd()
         .current_dir(temp_dir.path())
-        .env("SHELL", "/bin/true")
+        .env("SHELL", &true_bin)
         .args(["activate", "--profile", "generic"])
         .assert()
         .success();
@@ -708,7 +724,7 @@ fn test_activate_profile_cache_with_real_nix_when_available() {
 
     flk_cmd()
         .current_dir(temp_dir.path())
-        .env("SHELL", "/bin/true")
+        .env("SHELL", &true_bin)
         .args(["activate", "--profile", "generic"])
         .assert()
         .success();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -572,7 +572,7 @@ fn test_activate_uses_shell_fallback_and_profile_gc_root() {
             "-c",
             "/bin/sh",
             "-c",
-            "if [ -e \"$FLK_PROFILE_PATH\" ]; then mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; touch \"$FLK_PROFILE_STAMP\"; fi; exec \"$FLK_SHELL_CMD\"",
+            "if [ -e \"$FLK_PROFILE_PATH\" ]; then mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; touch \"$FLK_PROFILE_STAMP\" || exit 1; fi; exec \"$FLK_SHELL_CMD\"",
         ]
     );
 }
@@ -685,7 +685,7 @@ fn test_activate_refreshes_stale_profile_cache() {
             "-c",
             "/bin/sh",
             "-c",
-            "if [ -e \"$FLK_PROFILE_PATH\" ]; then mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; touch \"$FLK_PROFILE_STAMP\"; fi; exec \"$FLK_SHELL_CMD\"",
+            "if [ -e \"$FLK_PROFILE_PATH\" ]; then mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; touch \"$FLK_PROFILE_STAMP\" || exit 1; fi; exec \"$FLK_SHELL_CMD\"",
         ]
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -49,7 +49,9 @@ fn real_nix_tests_enabled() -> bool {
     std::process::Command::new("nix")
         .args([
             "--extra-experimental-features",
-            "nix-command flakes",
+            "nix-command",
+            "--extra-experimental-features",
+            "flakes",
             "flake",
             "metadata",
             "--help",

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -680,12 +680,19 @@ fn test_activate_profile_cache_with_real_nix_when_available() {
 
     let first_stamp_mtime = fs::metadata(&stamp_path).unwrap().modified().unwrap();
 
+    // Second activation should reuse the cached profile (stamp unchanged).
     flk_cmd()
         .current_dir(temp_dir.path())
         .env("SHELL", "/bin/true")
         .args(["activate", "--profile", "generic"])
         .assert()
         .success();
+
+    let reused_stamp_mtime = fs::metadata(&stamp_path).unwrap().modified().unwrap();
+    assert_eq!(
+        first_stamp_mtime, reused_stamp_mtime,
+        "expected cache stamp to remain unchanged when reusing cached profile"
+    );
 
     let flake_path = temp_dir.path().join("flake.nix");
     let original_flake = fs::read_to_string(&flake_path).unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -491,9 +491,8 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("\"${SHELL:-/bin/sh}\""))
         .stdout(contains("exec \"$FLK_SHELL_CMD\""))
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
-        .stdout(contains(
-            "export FLK_PROFILE=\".#$profile\"\n    _flk_exec_nix_develop",
-        ))
+        .stdout(contains("export FLK_PROFILE=\".#$profile\""))
+        .stdout(contains("_flk_exec_nix_develop \".#$profile\""))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -504,9 +503,8 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("\"${SHELL:-/bin/sh}\""))
         .stdout(contains("exec \"$FLK_SHELL_CMD\""))
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
-        .stdout(contains(
-            "export FLK_PROFILE=\".#$profile\"\n    _flk_exec_nix_develop",
-        ))
+        .stdout(contains("export FLK_PROFILE=\".#$profile\""))
+        .stdout(contains("_flk_exec_nix_develop \".#$profile\""))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -520,9 +518,8 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("-c \"$flk_shell\""))
         .stdout(contains("exec \"$FLK_SHELL_CMD\""))
         .stdout(contains("set -lx FLK_FLAKE_REF \".#$profile\""))
-        .stdout(contains(
-            "set -lx FLK_PROFILE \".#$profile\"\n    set -l flk_shell",
-        ))
+        .stdout(contains("set -lx FLK_PROFILE \".#$profile\""))
+        .stdout(contains("set -l flk_shell"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -489,6 +489,11 @@ fn test_hook_shells_include_shell_command() {
         .assert()
         .success()
         .stdout(contains("\"${SHELL:-/bin/sh}\""))
+        .stdout(contains("exec \"$FLK_SHELL_CMD\""))
+        .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
+        .stdout(contains(
+            "export FLK_PROFILE=\".#$profile\"\n    _flk_exec_nix_develop",
+        ))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -497,6 +502,11 @@ fn test_hook_shells_include_shell_command() {
         .assert()
         .success()
         .stdout(contains("\"${SHELL:-/bin/sh}\""))
+        .stdout(contains("exec \"$FLK_SHELL_CMD\""))
+        .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
+        .stdout(contains(
+            "export FLK_PROFILE=\".#$profile\"\n    _flk_exec_nix_develop",
+        ))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -508,6 +518,11 @@ fn test_hook_shells_include_shell_command() {
             "set -l flk_shell (test -n \"$SHELL\"; and echo \"$SHELL\"; or echo \"/bin/sh\")",
         ))
         .stdout(contains("-c \"$flk_shell\""))
+        .stdout(contains("exec \"$FLK_SHELL_CMD\""))
+        .stdout(contains("set -lx FLK_FLAKE_REF \".#$profile\""))
+        .stdout(contains(
+            "set -lx FLK_PROFILE \".#$profile\"\n    set -l flk_shell",
+        ))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 }
@@ -559,6 +574,8 @@ fn test_activate_uses_shell_fallback_and_profile_gc_root() {
             ".flk/.nix-profile-generic",
             "-c",
             "/bin/sh",
+            "-c",
+            "if [ -e \"$FLK_PROFILE_PATH\" ]; then mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; touch \"$FLK_PROFILE_STAMP\"; fi; exec \"$FLK_SHELL_CMD\"",
         ]
     );
 }
@@ -670,6 +687,8 @@ fn test_activate_refreshes_stale_profile_cache() {
             ".flk/.nix-profile-generic",
             "-c",
             "/bin/sh",
+            "-c",
+            "if [ -e \"$FLK_PROFILE_PATH\" ]; then mkdir -p \"$(dirname \"$FLK_PROFILE_STAMP\")\"; touch \"$FLK_PROFILE_STAMP\"; fi; exec \"$FLK_SHELL_CMD\"",
         ]
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -40,6 +40,15 @@ fn set_modified_time(path: &Path, modified: std::time::SystemTime) {
     file.set_times(times).unwrap();
 }
 
+#[cfg(unix)]
+fn nix_available() -> bool {
+    std::process::Command::new("nix")
+        .arg("--version")
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 #[test]
 fn test_version() {
     flk_cmd()
@@ -489,6 +498,7 @@ fn test_hook_shells_include_shell_command() {
         .assert()
         .success()
         .stdout(contains("\"${SHELL:-/bin/sh}\""))
+        .stdout(predicate::str::contains("FLK_REF=\"").not())
         .stdout(contains("exec \"$FLK_SHELL_CMD\""))
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
         .stdout(contains("export FLK_PROFILE=\".#$profile\""))
@@ -501,6 +511,7 @@ fn test_hook_shells_include_shell_command() {
         .assert()
         .success()
         .stdout(contains("\"${SHELL:-/bin/sh}\""))
+        .stdout(predicate::str::contains("FLK_REF=\"").not())
         .stdout(contains("exec \"$FLK_SHELL_CMD\""))
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
         .stdout(contains("export FLK_PROFILE=\".#$profile\""))
@@ -512,6 +523,7 @@ fn test_hook_shells_include_shell_command() {
         .args(["hook", "fish"])
         .assert()
         .success()
+        .stdout(predicate::str::contains("FLK_REF=\"").not())
         .stdout(contains(
             "set -l flk_shell (test -n \"$SHELL\"; and echo \"$SHELL\"; or echo \"/bin/sh\")",
         ))
@@ -627,6 +639,77 @@ fn test_activate_reuses_fresh_profile_cache() {
             "-c",
             "/bin/sh",
         ]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_activate_profile_cache_with_real_nix_when_available() {
+    if !nix_available() {
+        eprintln!("skipping test_activate_profile_cache_with_real_nix_when_available: `nix` not available");
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let profile_path = temp_dir.path().join(".flk/.nix-profile-generic");
+    let stamp_path = temp_dir.path().join(".flk/.nix-profile-generic.stamp");
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .env("SHELL", "/bin/true")
+        .args(["activate", "--profile", "generic"])
+        .assert()
+        .success();
+
+    assert!(
+        profile_path.exists(),
+        "expected first activation to create cached profile at {}",
+        profile_path.display()
+    );
+    assert!(
+        stamp_path.exists(),
+        "expected first activation to create cache stamp at {}",
+        stamp_path.display()
+    );
+
+    let first_stamp_mtime = fs::metadata(&stamp_path).unwrap().modified().unwrap();
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .env("SHELL", "/bin/true")
+        .args(["activate", "--profile", "generic"])
+        .assert()
+        .success();
+
+    let flake_path = temp_dir.path().join("flake.nix");
+    let original_flake = fs::read_to_string(&flake_path).unwrap();
+    fs::write(
+        &flake_path,
+        format!("{original_flake}\n# force cache refresh\n"),
+    )
+    .unwrap();
+    set_modified_time(
+        &flake_path,
+        std::time::SystemTime::now() + std::time::Duration::from_secs(2),
+    );
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .env("SHELL", "/bin/true")
+        .args(["activate", "--profile", "generic"])
+        .assert()
+        .success();
+
+    let refreshed_stamp_mtime = fs::metadata(&stamp_path).unwrap().modified().unwrap();
+    assert!(
+        refreshed_stamp_mtime > first_stamp_mtime,
+        "expected cache stamp to be refreshed after flake input changed"
     );
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -29,6 +29,17 @@ fn make_executable(path: &Path) {
     fs::set_permissions(path, permissions).unwrap();
 }
 
+#[cfg(unix)]
+fn set_modified_time(path: &Path, modified: std::time::SystemTime) {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .unwrap();
+    let times = fs::FileTimes::new().set_modified(modified);
+    file.set_times(times).unwrap();
+}
+
 #[test]
 fn test_version() {
     flk_cmd()
@@ -576,7 +587,6 @@ fn test_activate_reuses_fresh_profile_cache() {
         .assert()
         .success();
 
-    std::thread::sleep(std::time::Duration::from_secs(1));
     fs::write(&profile_path, "cached-profile").unwrap();
     fs::write(&stamp_path, "").unwrap();
 
@@ -615,7 +625,6 @@ fn test_activate_refreshes_stale_profile_cache() {
     let log_path = temp_dir.path().join("nix-args.log");
     let profile_path = temp_dir.path().join(".flk/.nix-profile-generic");
     let stamp_path = temp_dir.path().join(".flk/.nix-profile-generic.stamp");
-    let profile_file = temp_dir.path().join(".flk/profiles/generic.nix");
 
     fs::create_dir_all(&fake_bin_dir).unwrap();
     fs::write(
@@ -633,12 +642,10 @@ fn test_activate_refreshes_stale_profile_cache() {
 
     fs::write(&profile_path, "cached-profile").unwrap();
     fs::write(&stamp_path, "").unwrap();
-    std::thread::sleep(std::time::Duration::from_secs(1));
-    fs::write(
-        &profile_file,
-        fs::read_to_string(&profile_file).unwrap() + "\n# stale\n",
-    )
-    .unwrap();
+    set_modified_time(
+        &stamp_path,
+        std::time::UNIX_EPOCH + std::time::Duration::from_secs(1),
+    );
 
     flk_cmd()
         .current_dir(temp_dir.path())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -522,7 +522,7 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
         .stdout(contains("export FLK_PROFILE=\".#$profile\""))
         .stdout(contains("_flk_exec_nix_develop \".#$profile\""))
-        .stdout(contains("[ \"$stamp_path\" -nt \"$f\" ] || return 1"))
+        .stdout(contains("[ \"$f\" -nt \"$stamp_path\" ] && return 1"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -536,7 +536,7 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("export FLK_FLAKE_REF=\".#$profile\""))
         .stdout(contains("export FLK_PROFILE=\".#$profile\""))
         .stdout(contains("_flk_exec_nix_develop \".#$profile\""))
-        .stdout(contains("[ \"$stamp_path\" -nt \"$f\" ] || return 1"))
+        .stdout(contains("[ \"$f\" -nt \"$stamp_path\" ] && return 1"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 
@@ -553,7 +553,7 @@ fn test_hook_shells_include_shell_command() {
         .stdout(contains("set -gx FLK_FLAKE_REF"))
         .stdout(contains("set -gx FLK_PROFILE"))
         .stdout(contains("set -l flk_shell"))
-        .stdout(contains("test \"$stamp_path\" -nt \"$f\"; or return 1"))
+        .stdout(contains("test \"$f\" -nt \"$stamp_path\"; and return 1"))
         .stdout(contains(".nix-profile-"))
         .stdout(contains(".stamp"));
 }
@@ -653,6 +653,75 @@ fn test_activate_reuses_fresh_profile_cache() {
     }
     let fresh_stamp_mtime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(2);
     set_modified_time(&stamp_path, fresh_stamp_mtime);
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .env("PATH", prepend_path(&fake_bin_dir))
+        .env("FAKE_NIX_LOG", &log_path)
+        .env_remove("SHELL")
+        .args(["activate", "--profile", "generic"])
+        .assert()
+        .success();
+
+    let args: Vec<String> = fs::read_to_string(&log_path)
+        .unwrap()
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect();
+    assert_eq!(
+        args,
+        vec![
+            "develop",
+            ".flk/.nix-profile-generic",
+            "--impure",
+            "-c",
+            "/bin/sh",
+        ]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_activate_reuses_cache_when_stamp_equals_input_mtime() {
+    let temp_dir = TempDir::new().unwrap();
+    let fake_bin_dir = temp_dir.path().join("bin");
+    let fake_nix_path = fake_bin_dir.join("nix");
+    let log_path = temp_dir.path().join("nix-args.log");
+    let profile_path = temp_dir.path().join(".flk/.nix-profile-generic");
+    let stamp_path = temp_dir.path().join(".flk/.nix-profile-generic.stamp");
+
+    fs::create_dir_all(&fake_bin_dir).unwrap();
+    fs::write(
+        &fake_nix_path,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$FAKE_NIX_LOG\"\n",
+    )
+    .unwrap();
+    make_executable(&fake_nix_path);
+
+    flk_cmd()
+        .current_dir(temp_dir.path())
+        .arg("init")
+        .assert()
+        .success();
+
+    fs::write(&profile_path, "cached-profile").unwrap();
+    fs::write(&stamp_path, "").unwrap();
+
+    let equal_mtime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(2);
+    for input in [
+        "flake.nix",
+        "flake.lock",
+        ".flk/default.nix",
+        ".flk/pins.nix",
+        ".flk/overlays.nix",
+        ".flk/profiles/generic.nix",
+    ] {
+        let input_path = temp_dir.path().join(input);
+        if input_path.exists() {
+            set_modified_time(&input_path, equal_mtime);
+        }
+    }
+    set_modified_time(&stamp_path, equal_mtime);
 
     flk_cmd()
         .current_dir(temp_dir.path())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -642,10 +642,9 @@ fn test_activate_refreshes_stale_profile_cache() {
 
     fs::write(&profile_path, "cached-profile").unwrap();
     fs::write(&stamp_path, "").unwrap();
-    set_modified_time(
-        &stamp_path,
-        std::time::UNIX_EPOCH + std::time::Duration::from_secs(1),
-    );
+    // Force an obviously stale stamp timestamp so tracked inputs are always newer.
+    let stale_stamp_mtime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1);
+    set_modified_time(&stamp_path, stale_stamp_mtime);
 
     flk_cmd()
         .current_dir(temp_dir.path())


### PR DESCRIPTION
This pull request introduces a robust caching mechanism for `nix develop` profiles in the `flk` tool, improving shell startup speed and efficiency. Now, profile environments are reused from cache when the environment definition has not changed, and automatically refreshed when relevant files are updated. The implementation includes both Rust and shell logic, comprehensive tests, and updated documentation.

**Caching and Profile Reuse Improvements**
- Added logic in `activate.rs` and shell hooks to reuse a cached `.flk/.nix-profile-<profile>` when unchanged, and refresh it when any of `flake.nix`, `flake.lock`, or relevant `.flk` files are modified. This includes stamp files to track cache freshness. [[1]](diffhunk://#diff-e5f9986151de4581ad75de793d28250a9db1e455bf7130e46e6f96c8f6e5b4f8L8-R26) [[2]](diffhunk://#diff-e5f9986151de4581ad75de793d28250a9db1e455bf7130e46e6f96c8f6e5b4f8L27-R57) [[3]](diffhunk://#diff-e5f9986151de4581ad75de793d28250a9db1e455bf7130e46e6f96c8f6e5b4f8R68-R70) [[4]](diffhunk://#diff-e5f9986151de4581ad75de793d28250a9db1e455bf7130e46e6f96c8f6e5b4f8R79-R144) [[5]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaR34-R66) [[6]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL46-R79) [[7]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL64-R97) [[8]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaR115-R154) [[9]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL94-R167) [[10]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL113-R186)

**Shell Integration**
- Refactored the shell hook logic (`hook.rs`) for bash, zsh, and fish to use the new cache-aware profile execution, ensuring consistent behavior across environments. [[1]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaR34-R66) [[2]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL46-R79) [[3]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL64-R97) [[4]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaR115-R154) [[5]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL94-R167) [[6]](diffhunk://#diff-9ec516944f80af910aeed530b6f861195efe35da305d167e2ebf2eab62f183aaL113-R186)

**Documentation Updates**
- Updated the documentation to clarify new behavior: profiles are now cached and only rebuilt when environment definitions change, with details on what triggers a refresh. [[1]](diffhunk://#diff-7a79c85d58853ce30ca3d2c6e06853c24cdf6da64ba08a08c66b97125677fa64L15-R16) [[2]](diffhunk://#diff-f337a2ecbeac0fa138579abe4dbf8ee6f54d608fbef5f5c2832836d6e9e8aad6L46-R47) [[3]](diffhunk://#diff-f337a2ecbeac0fa138579abe4dbf8ee6f54d608fbef5f5c2832836d6e9e8aad6R61) [[4]](diffhunk://#diff-c9a47820a9104e6b9a29ad4eaf2c7ce9ebd292dab6301d265e028dfb86b852f6L35-R36) [[5]](diffhunk://#diff-c9a47820a9104e6b9a29ad4eaf2c7ce9ebd292dab6301d265e028dfb86b852f6L50-R51)

**Testing**
- Added and updated integration tests to verify that the cache is reused when fresh and rebuilt when stale, and that the new logic is reflected in shell hooks. [[1]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L480-R490) [[2]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L495-R501) [[3]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0R555-R670)

These changes make `flk` significantly faster and more reliable for developers switching between profiles and environments.
